### PR TITLE
fix: add items to parameter schema

### DIFF
--- a/src/toolbox_llamaindex_sdk/utils.py
+++ b/src/toolbox_llamaindex_sdk/utils.py
@@ -27,6 +27,7 @@ class ParameterSchema(BaseModel):
     type: str
     description: str
     authSources: Optional[list[str]] = None
+    items: Optional["ParameterSchema"] = None
 
 
 class ToolSchema(BaseModel):
@@ -83,7 +84,7 @@ def _schema_to_model(model_name: str, schema: list[ParameterSchema]) -> Type[Bas
             (
                 # TODO: Remove the hardcoded optional types once optional fields
                 # are supported by Toolbox.
-                Optional[_parse_type(field.type)],
+                Optional[_parse_type(field)],
                 Field(description=field.description),
             ),
         )
@@ -91,16 +92,17 @@ def _schema_to_model(model_name: str, schema: list[ParameterSchema]) -> Type[Bas
     return create_model(model_name, **field_definitions)
 
 
-def _parse_type(type_: str) -> Any:
+def _parse_type(schema_: ParameterSchema) -> Any:
     """
     Converts a schema type to a JSON type.
 
     Args:
-        type_: The type name to convert.
+        schema_: The ParameterSchema to convert.
 
     Returns:
         A valid JSON type.
     """
+    type_ = schema_.type
 
     if type_ == "string":
         return str
@@ -111,7 +113,10 @@ def _parse_type(type_: str) -> Any:
     elif type_ == "boolean":
         return bool
     elif type_ == "array":
-        return list
+        if isinstance(schema_, ParameterSchema) and schema_.items:
+            return list[_parse_type(schema_.items)]  # type: ignore
+        else:
+            raise ValueError(f"Schema missing field items")
     else:
         raise ValueError(f"Unsupported schema type: {type_}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contains pytest fixtures that are accessible from all 
+"""Contains pytest fixtures that are accessible from all
 files present in the same directory."""
 
 from __future__ import annotations

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -165,21 +165,47 @@ class TestUtils:
         assert len(model.model_fields) == 0
 
     @pytest.mark.parametrize(
-        "type_string, expected_type",
+        "parameter_schema, expected_type",
         [
-            ("string", str),
-            ("integer", int),
-            ("float", float),
-            ("boolean", bool),
-            ("array", list),
+            (ParameterSchema(name="foo", description="bar", type="string"), str),
+            (ParameterSchema(name="foo", description="bar", type="integer"), int),
+            (ParameterSchema(name="foo", description="bar", type="float"), float),
+            (ParameterSchema(name="foo", description="bar", type="boolean"), bool),
+            (
+                ParameterSchema(
+                    name="foo",
+                    description="bar",
+                    type="array",
+                    items=ParameterSchema(
+                        name="foo", description="bar", type="integer"
+                    ),
+                ),
+                list[int],
+            ),
         ],
     )
-    def test_parse_type(self, type_string, expected_type):
-        assert _parse_type(type_string) == expected_type
+    def test_parse_type(self, parameter_schema, expected_type):
+        assert _parse_type(parameter_schema) == expected_type
 
-    def test_parse_type_invalid(self):
+    @pytest.mark.parametrize(
+        "fail_parameter_schema",
+        [
+            (ParameterSchema(name="foo", description="bar", type="invalid")),
+            (
+                ParameterSchema(
+                    name="foo",
+                    description="bar",
+                    type="array",
+                    items=ParameterSchema(
+                        name="foo", description="bar", type="invalid"
+                    ),
+                )
+            ),
+        ],
+    )
+    def test_parse_type_invalid(self, fail_parameter_schema):
         with pytest.raises(ValueError):
-            _parse_type("invalid")
+            _parse_type(fail_parameter_schema)
 
     @pytest.mark.asyncio
     @patch("aiohttp.ClientSession.post")


### PR DESCRIPTION
Fix issue with array parameter type throwing an error `generic::invalid_argument: Unable to submit request because search_airports functionDeclaration parameters.airlines schema didn't specify the schema type field.`

This PR does the following:
* Parse items from manifest to `ParameterSchema`.
* Convert item typing to specific type instead of using `Union`.