### PR TITLE
chore: remove temp fix for optional params support

### DIFF
--- a/src/toolbox_llamaindex/utils.py
+++ b/src/toolbox_llamaindex/utils.py
@@ -198,35 +198,11 @@ async def _invoke_tool(
 
     async with session.post(
         url,
-        json=_convert_none_to_empty_string(data),
+        json=data,
         headers=auth_tokens,
     ) as response:
         response.raise_for_status()
         return await response.json()
-
-
-def _convert_none_to_empty_string(input_dict):
-    """
-    Temporary fix to convert None values to empty strings in the input data.
-    This is needed because the current version of the Toolbox service does not
-    support optional fields.
-
-    TODO: Remove this once optional fields are supported by Toolbox.
-
-    Args:
-        input_dict: The input data dictionary.
-
-    Returns:
-        A new dictionary with None values replaced by empty strings.
-    """
-    new_dict = {}
-    for key, value in input_dict.items():
-        if value is None:
-            new_dict[key] = ""
-        else:
-            new_dict[key] = value
-    return new_dict
-
 
 def _find_auth_params(
     params: list[ParameterSchema],

--- a/src/toolbox_llamaindex/utils.py
+++ b/src/toolbox_llamaindex/utils.py
@@ -97,9 +97,7 @@ def _schema_to_model(model_name: str, schema: list[ParameterSchema]) -> Type[Bas
         field_definitions[field.name] = cast(
             Any,
             (
-                # TODO: Remove the hardcoded optional types once optional fields
-                # are supported by Toolbox.
-                Optional[_parse_type(field)],
+                _parse_type(field),
                 Field(description=field.description),
             ),
         )

--- a/src/toolbox_llamaindex/utils.py
+++ b/src/toolbox_llamaindex/utils.py
@@ -204,6 +204,7 @@ async def _invoke_tool(
         response.raise_for_status()
         return await response.json()
 
+
 def _find_auth_params(
     params: list[ParameterSchema],
 ) -> tuple[list[ParameterSchema], list[ParameterSchema]]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,6 @@ from pydantic import BaseModel
 
 from toolbox_llamaindex.utils import (
     ParameterSchema,
-    _convert_none_to_empty_string,
     _get_auth_headers,
     _invoke_tool,
     _load_manifest,
@@ -225,7 +224,7 @@ class TestUtils:
 
         mock_post.assert_called_once_with(
             "http://localhost:8000/api/tool/tool_name/invoke",
-            json=_convert_none_to_empty_string({"input": "data"}),
+            json={"input": "data"},
             headers={},
         )
         assert result == {"key": "value"}
@@ -252,7 +251,7 @@ class TestUtils:
 
         mock_post.assert_called_once_with(
             "http://localhost:8000/api/tool/tool_name/invoke",
-            json=_convert_none_to_empty_string({"input": "data"}),
+            json={"input": "data"},
             headers={"my_test_auth_token": "fake_id_token"},
         )
         assert result == {"key": "value"}
@@ -278,15 +277,10 @@ class TestUtils:
 
         mock_post.assert_called_once_with(
             "https://localhost:8000/api/tool/tool_name/invoke",
-            json=_convert_none_to_empty_string({"input": "data"}),
+            json={"input": "data"},
             headers={"my_test_auth_token": "fake_id_token"},
         )
         assert result == {"key": "value"}
-
-    def test_convert_none_to_empty_string(self):
-        input_dict = {"a": None, "b": 123}
-        expected_output = {"a": "", "b": 123}
-        assert _convert_none_to_empty_string(input_dict) == expected_output
 
     def test_get_auth_headers_deprecation_warning(self):
         """Test _get_auth_headers deprecation warning."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,9 +154,9 @@ class TestUtils:
         model = _schema_to_model("TestModel", schema)
         assert issubclass(model, BaseModel)
 
-        assert model.model_fields["param1"].annotation == Union[str, None]
+        assert model.model_fields["param1"].annotation == str
         assert model.model_fields["param1"].description == "Parameter 1"
-        assert model.model_fields["param2"].annotation == Union[int, None]
+        assert model.model_fields["param2"].annotation == int
         assert model.model_fields["param2"].description == "Parameter 2"
 
     def test_schema_to_model_empty(self):


### PR DESCRIPTION
We're currently not using optional parameters in Toolbox, as they create compatibility problems with LlamaIndex agents that utilize the [AgentWorkflow](https://docs.llamaindex.ai/en/stable/examples/agent/agent_workflow_basic/) class.

Using AgentWorkflow with Optional Parameters support would need some workarounds which will be investigated upon the addition of the `Optional Parameters` functionality.

The current implementation of each tool contains tool properties with tool types being any of `String` or `Null`.
```
'param1': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'description': ..., 'title': ...}
```

The Agent Workflow needs params to have a single type like:

```
 'param1': {'type': 'string', 'description': ..., 'title': ...}
```