### PR TITLE
chore: Update GHA workflow permissions for Cloud Build Reporter

### DIFF
--- a/.github/workflows/schedule_reporter.yml
+++ b/.github/workflows/schedule_reporter.yml
@@ -19,6 +19,10 @@ on:
     - cron: '0 6 * * *'  # Runs at 6 AM every morning
 
 jobs:
+  permissions:
+      issues: 'write'
+      checks: 'read'
+      contents: 'read'
   run_reporter:
     uses: ./.github/workflows/cloud_build_failure_reporter.yml
     with:


### PR DESCRIPTION
Based on https://github.com/googleapis/langchain-google-alloydb-pg-python/pull/384