### PR TITLE
chore: Update GHA workflow permissions for Cloud Build Reporter

### DIFF
--- a/.github/workflows/schedule_reporter.yml
+++ b/.github/workflows/schedule_reporter.yml
@@ -20,6 +20,10 @@ on:
 
 jobs:
   run_reporter:
+    permissions:
+        issues: 'write'
+        checks: 'read'
+        contents: 'read'
     uses: ./.github/workflows/cloud_build_failure_reporter.yml
     with:
       trigger_names: "llamaindex-python-sdk-test-nightly,llamaindex-python-sdk-test-on-merge"


### PR DESCRIPTION
[Seems like](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#example-caller-workflow) GH workflows job permissions are provided inside the job level indent, so that it can be passed down transitively to `cloud_build_failure_reporter`.

We already verified that the `cloud_build_failure_reporter` job is independently working when triggered manually.

<img width="1001" alt="Screenshot 2025-03-13 at 22 49 17" src="https://github.com/user-attachments/assets/5d50c16e-c37d-464e-b01e-17e83dd85dbf" />
