### PR TITLE
chore(deps): Update deps to work with llamaIndex AgentWorkflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
 dependencies = [
-    "llama-index>=0.11.2,<1.0.0",
+    "llama-index>=0.12.0,<1.0.0",
     "PyYAML>=6.0.1,<7.0.0",
-    "pydantic>=2.7.0,<3.0.0",
+    "pydantic>=2.8.0,<3.0.0",
     "aiohttp>=3.8.6,<4.0.0",
-    "deprecated>=1.1.0,<2.0.0",
+    "deprecated>=1.2.10,<2.0.0",
 ]
 
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-llama-index==0.12.2
+llama-index==0.12.24
 PyYAML==6.0.2
-pydantic==2.10.2
-aiohttp==3.11.7
-deprecated==1.2.15
+pydantic==2.10.6
+aiohttp==3.11.14
+deprecated==1.2.18


### PR DESCRIPTION
Update deps to make sure `toolbox-llamaindex` works with [AgentWorkflow](https://docs.llamaindex.ai/en/stable/examples/agent/agent_workflow_basic/).

Quickstart: https://github.com/googleapis/genai-toolbox/pull/318