### PR TITLE
fix: throw tool errors correctly.

### DIFF
--- a/src/toolbox_llamaindex/async_tools.py
+++ b/src/toolbox_llamaindex/async_tools.py
@@ -179,16 +179,25 @@ class AsyncToolboxTool(AsyncBaseTool):
 
         # Merge bound parameters with the provided arguments
         kwargs.update(evaluated_params)
-        response = await _invoke_tool(
-            self.__url, self.__session, self.__name, kwargs, self.__auth_tokens
-        )
-        return ToolOutput(
-            content=str(response),
-            tool_name=self.__name,
-            raw_input=kwargs,
-            raw_output=response,
-            is_error=False,
-        )
+        try:
+            response = await _invoke_tool(
+                self.__url, self.__session, self.__name, kwargs, self.__auth_tokens
+            )
+            return ToolOutput(
+                content=str(response),
+                tool_name=self.__name,
+                raw_input=kwargs,
+                raw_output=response,
+                is_error=False,
+            )
+        except ClientResponseError as e:
+            return ToolOutput(
+                content="Encountered error: " + str(e),
+                tool_name=self.__name,
+                raw_input=kwargs,
+                raw_output=str(e),
+                is_error=True,
+            )
 
     def __validate_auth(self, strict: bool = True) -> None:
         """

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -130,7 +130,8 @@ class TestE2EClientAsync:
         response = await tool.acall(id="2")
         assert response.is_error == True
         assert "401, message='Unauthorized'" in response.content
-        assert isinstance(response.raw_output, ClientResponseError)
+        assert isinstance(response.raw_output, str)
+        assert "ClientResponseError" in response.raw_output
 
     async def test_run_tool_wrong_auth(self, toolbox, auth_token2):
         """Tests running a tool with incorrect auth."""
@@ -141,7 +142,8 @@ class TestE2EClientAsync:
         response = await auth_tool.acall(id="2")
         assert response.is_error == True
         assert "401, message='Unauthorized'" in response.content
-        assert isinstance(response.raw_output, ClientResponseError)
+        assert isinstance(response.raw_output, str)
+        assert "ClientResponseError" in response.raw_output
 
     async def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""
@@ -180,7 +182,8 @@ class TestE2EClientAsync:
         response = await tool.acall()
         assert response.is_error == True
         assert "400, message='Bad Request'" in response.content
-        assert isinstance(response.raw_output, ClientResponseError)
+        assert isinstance(response.raw_output, str)
+        assert "ClientResponseError" in response.raw_output
 
 
 @pytest.mark.usefixtures("toolbox_server")
@@ -270,7 +273,8 @@ class TestE2EClientSync:
         response = tool.call(id="2")
         assert response.is_error == True
         assert "401, message='Unauthorized'" in response.content
-        assert isinstance(response.raw_output, ClientResponseError)
+        assert isinstance(response.raw_output, str)
+        assert "ClientResponseError" in response.raw_output
 
     def test_run_tool_wrong_auth(self, toolbox, auth_token2):
         """Tests running a tool with incorrect auth."""
@@ -281,7 +285,8 @@ class TestE2EClientSync:
         response = auth_tool.call(id="2")
         assert response.is_error == True
         assert "401, message='Unauthorized'" in response.content
-        assert isinstance(response.raw_output, ClientResponseError)
+        assert isinstance(response.raw_output, str)
+        assert "ClientResponseError" in response.raw_output
 
     def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""
@@ -320,4 +325,5 @@ class TestE2EClientSync:
         response = tool.call()
         assert response.is_error == True
         assert "400, message='Bad Request'" in response.content
-        assert isinstance(response.raw_output, ClientResponseError)
+        assert isinstance(response.raw_output, str)
+        assert "ClientResponseError" in response.raw_output

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -127,8 +127,10 @@ class TestE2EClientAsync:
         tool = await toolbox.aload_tool(
             "get-row-by-id-auth",
         )
-        with pytest.raises(ClientResponseError, match="401, message='Unauthorized'"):
-            await tool.acall(id="2")
+        response = await tool.acall(id="2")
+        assert response.is_error == True
+        assert "401, message='Unauthorized'" in response.content
+        assert isinstance(response.raw_output, ClientResponseError)
 
     async def test_run_tool_wrong_auth(self, toolbox, auth_token2):
         """Tests running a tool with incorrect auth."""
@@ -136,8 +138,10 @@ class TestE2EClientAsync:
             "get-row-by-id-auth",
         )
         auth_tool = tool.add_auth_token("my-test-auth", lambda: auth_token2)
-        with pytest.raises(ClientResponseError, match="401, message='Unauthorized'"):
-            await auth_tool.acall(id="2")
+        response = await auth_tool.acall(id="2")
+        assert response.is_error == True
+        assert "401, message='Unauthorized'" in response.content
+        assert isinstance(response.raw_output, ClientResponseError)
 
     async def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""
@@ -173,8 +177,10 @@ class TestE2EClientAsync:
         tool = await toolbox.aload_tool(
             "get-row-by-content-auth", auth_tokens={"my-test-auth": lambda: auth_token1}
         )
-        with pytest.raises(ClientResponseError, match="400, message='Bad Request'"):
-            await tool.acall()
+        response = await tool.acall()
+        assert response.is_error == True
+        assert "400, message='Bad Request'" in response.content
+        assert isinstance(response.raw_output, ClientResponseError)
 
 
 @pytest.mark.usefixtures("toolbox_server")
@@ -261,8 +267,10 @@ class TestE2EClientSync:
         tool = toolbox.load_tool(
             "get-row-by-id-auth",
         )
-        with pytest.raises(ClientResponseError, match="401, message='Unauthorized'"):
-            tool.call(id="2")
+        response = tool.call(id="2")
+        assert response.is_error == True
+        assert "401, message='Unauthorized'" in response.content
+        assert isinstance(response.raw_output, ClientResponseError)
 
     def test_run_tool_wrong_auth(self, toolbox, auth_token2):
         """Tests running a tool with incorrect auth."""
@@ -270,9 +278,10 @@ class TestE2EClientSync:
             "get-row-by-id-auth",
         )
         auth_tool = tool.add_auth_token("my-test-auth", lambda: auth_token2)
-
-        with pytest.raises(ClientResponseError, match="401, message='Unauthorized'"):
-            auth_tool.call(id="2")
+        response = auth_tool.call(id="2")
+        assert response.is_error == True
+        assert "401, message='Unauthorized'" in response.content
+        assert isinstance(response.raw_output, ClientResponseError)
 
     def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""
@@ -308,5 +317,7 @@ class TestE2EClientSync:
         tool = toolbox.load_tool(
             "get-row-by-content-auth", auth_tokens={"my-test-auth": lambda: auth_token1}
         )
-        with pytest.raises(ClientResponseError, match="400, message='Bad Request'"):
-            tool.call(id="2")
+        response = tool.call()
+        assert response.is_error == True
+        assert "400, message='Bad Request'" in response.content
+        assert isinstance(response.raw_output, ClientResponseError)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -131,7 +131,6 @@ class TestE2EClientAsync:
         assert response.is_error == True
         assert "401, message='Unauthorized'" in response.content
         assert isinstance(response.raw_output, str)
-        assert "ClientResponseError" in response.raw_output
 
     async def test_run_tool_wrong_auth(self, toolbox, auth_token2):
         """Tests running a tool with incorrect auth."""
@@ -143,7 +142,6 @@ class TestE2EClientAsync:
         assert response.is_error == True
         assert "401, message='Unauthorized'" in response.content
         assert isinstance(response.raw_output, str)
-        assert "ClientResponseError" in response.raw_output
 
     async def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""
@@ -183,7 +181,6 @@ class TestE2EClientAsync:
         assert response.is_error == True
         assert "400, message='Bad Request'" in response.content
         assert isinstance(response.raw_output, str)
-        assert "ClientResponseError" in response.raw_output
 
 
 @pytest.mark.usefixtures("toolbox_server")
@@ -274,7 +271,6 @@ class TestE2EClientSync:
         assert response.is_error == True
         assert "401, message='Unauthorized'" in response.content
         assert isinstance(response.raw_output, str)
-        assert "ClientResponseError" in response.raw_output
 
     def test_run_tool_wrong_auth(self, toolbox, auth_token2):
         """Tests running a tool with incorrect auth."""
@@ -286,7 +282,6 @@ class TestE2EClientSync:
         assert response.is_error == True
         assert "401, message='Unauthorized'" in response.content
         assert isinstance(response.raw_output, str)
-        assert "ClientResponseError" in response.raw_output
 
     def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""
@@ -326,4 +321,3 @@ class TestE2EClientSync:
         assert response.is_error == True
         assert "400, message='Bad Request'" in response.content
         assert isinstance(response.raw_output, str)
-        assert "ClientResponseError" in response.raw_output


### PR DESCRIPTION
Do not directly throw errors. Put errors in a ToolOutput object as [seen](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/tools/calling.py#L25) in the llamaindex repo.